### PR TITLE
fixed display spawn issue

### DIFF
--- a/webkitgtk.js
+++ b/webkitgtk.js
@@ -87,10 +87,10 @@ WebKit.prototype.init = function(opts, cb) {
 		opts.inspector = true;
 	}
 	opts.display = opts.display || 0;
-	display.call(this, opts, function(err, child) {
+	display.call(this, opts, function(err, child, newDisplay) {
 		if (err) return cb(err);
 		if (child) priv.xvfb = child;
-		process.env.DISPLAY = ":" + opts.display;
+		process.env.DISPLAY = ":" + newDisplay;
 		var Bindings = require(__dirname + '/lib/webkitgtk.node');
 		this.webview = new Bindings({
 			webextension: __dirname + '/lib/ext',
@@ -326,7 +326,8 @@ function display(opts, cb) {
 		}, display, function(err, child, display) {
 			if (err) cb(err);
 			else {
-				cb(null, child);
+				console.log("Spawned xvfb on DISPLAY=:" + display);
+				cb(null, child, display);
 				process.on('exit', function() {
 					child.kill();
 				});


### PR DESCRIPTION
There is an issue with the use of node-headless.

The invocation of `require('headless')` takes a parameter `display` -- a starting number to search for display.

Headless returns the display number that was used to spawn a new Xvfb and that number can be greater than the provided one
