### PR TITLE
added support for transparend background (libwebkitgtk 2.7.4 min)

### DIFF
--- a/src/webview.cc
+++ b/src/webview.cc
@@ -591,15 +591,22 @@ NAN_METHOD(WebView::Png) {
 	NanScope();
 	WebView* self = ObjectWrap::Unwrap<WebView>(args.This());
 
-	if (!args[0]->IsFunction()) {
-		NanThrowError("png(cb) missing cb argument");
+	if (!args[1]->IsFunction()) {
+		NanThrowError("png(opts, cb) missing cb argument");
 		NanReturnUndefined();
 	}
-	self->pngCallback = new NanCallback(args[0].As<Function>());
+	self->pngCallback = new NanCallback(args[1].As<Function>());
+
+	Local<Object> opts = args[0]->ToObject();
+	bool is_transparent_background = NanBooleanOptionValue(opts, H("transparent_background"), false);
+
+	WebKitSnapshotOptions snapshot_options =
+		(HAVE_TRANSPARENT_BACKGROUND && is_transparent_background ? WEBKIT_SNAPSHOT_OPTIONS_TRANSPARENT_BACKGROUND : WEBKIT_SNAPSHOT_OPTIONS_NONE);
+
 	webkit_web_view_get_snapshot(
 		self->view,
 		WEBKIT_SNAPSHOT_REGION_FULL_DOCUMENT,
-		WEBKIT_SNAPSHOT_OPTIONS_NONE,
+		snapshot_options,
 		NULL, //	GCancellable
 		WebView::PngFinished,
 		self

--- a/src/webview.h
+++ b/src/webview.h
@@ -17,6 +17,8 @@ public:
 	static const int DOCUMENT_AVAILABLE = 0;
 	static const int DOCUMENT_LOADING = 1;
 
+	static const int HAVE_TRANSPARENT_BACKGROUND = WEBKIT_CHECK_VERSION(2, 7, 4);
+
 	static void Init(Handle<Object>, Handle<Object>);
 	static void Exit(void*);
 

--- a/webkitgtk.js
+++ b/webkitgtk.js
@@ -703,6 +703,13 @@ function prepareRun(script, ticket, args, priv) {
 }
 
 WebKit.prototype.png = function(obj, cb) {
+  var opts = {};
+  if (typeof cb != "function") {
+    opts = cb;
+    cb = arguments[2];
+  }
+  cb = cb || noop;
+
 	var wstream;
 	if (typeof obj == "string") {
 		wstream = fs.createWriteStream(obj);
@@ -711,13 +718,12 @@ WebKit.prototype.png = function(obj, cb) {
 	} else {
 		return cb(new Error("png() first arg must be either a writableStream or a file path"));
 	}
-	cb = cb || noop;
-	png.call(this, wstream, cb);
+	png.call(this, wstream, opts, cb);
 };
 
-function png(wstream, cb) {
+function png(wstream, opts, cb) {
 	loop.call(this, true);
-	this.webview.png(function(err, buf) {
+	this.webview.png(opts, function(err, buf) {
 		if (err) {
 			loop.call(this, false);
 			wstream.emit('error', err);


### PR DESCRIPTION
* based on whether libwebkitgtk installed on the system has the version >= 2.7.4.

sample usage:
```
WebKit()
  .load(href)
  .wait('idle')
  .png('test.png'); // without transparent background (the same as before)
```
or
```
WebKit()
  .load(href)
  .wait('idle')
  .png('test.png', { transparent_background: true }); // use `true` | `false` to specify if the transparent background must be set in snapshot options.
```

can be checked for the following URL:
http://bob.provereno.ru/render/newbuildings/zverevo-derevnja-borisoglebskoe-161/badge.html


Let me know if there is something wrong or must be changed.
Or feel free to modify the code as needed.

--
FYI,
I built libwebkitgtk 2.7.4 the following way:
```
cmake .. -DPORT=GTK -DENABLE_WEB_AUDIO=OFF -DENABLE_VIDEO=OFF -DENABLE_VIDEO_TRACK=OFF
```
